### PR TITLE
fix: jest with node env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This is a proposal for the [Katas Node.js test](https://gitlab.com/exalt-it-dojo
 To start, create a `.env` file with this format. ([Don't forget to put your Krates ID](https://app.krat.es/dashboard))
 
 ```
-KRATES_ID="xxxxxxxxxxxxxxxxxxxx"
+NODE_ENV="dev"
+KRATES_ID="619205f54bd518ab9de7"
 ```
 
 Now you have to run some commands to init the project.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,7 @@ const rootPath = path.resolve(
 
 export const config = {
   rootPath,
+  env: env.get("NODE_ENV").default("dev").asString(),
   db: {
     kratesID: env.get("KRATES_ID").asString(),
     kratesUrlEndpoint: `https://krat.es/${env.get("KRATES_ID").asString()}`,

--- a/src/features/data_correction_junior/index.ts
+++ b/src/features/data_correction_junior/index.ts
@@ -22,7 +22,9 @@ export const dataCorrectionScript = async () => {
 
   const kratesService = new KratesService();
 
-  kratesService.createUsers(
-    require(`${config.data.dataCorrection.dirPath}/${config.data.dataCorrection.finalFileName}`)
-  );
+  // Specify to tests with jest to not push the data to Krates.
+  if (config.env !== "test")
+    kratesService.createUsers(
+      require(`${config.data.dataCorrection.dirPath}/${config.data.dataCorrection.finalFileName}`)
+    );
 };


### PR DESCRIPTION
# Business benefit
Prevent Krates from pushing users data when we start jest tests.

# What I did
- I add the NODE_ENV var to `.env` file.
- I put the env key to config with a default value to `dev`.
- I update the README.

# Checklist

- [x] I've updated the tests
- [x] I manually test my feature
- [x] I've updated the documentations

# How to verify
```bash
$ yarn test
```
--> Then, go to Krates collection targeted by the app, then check if new values has been added.
