### PR TITLE
fix: rename const on data correction service

### DIFF
--- a/src/features/data_correction_junior/services/DataCorrectionService.ts
+++ b/src/features/data_correction_junior/services/DataCorrectionService.ts
@@ -80,17 +80,17 @@ export class DataCorrectionService {
   async streamData({ dataName }: { dataName: string }): Promise<object> {
     return new Promise((resolve, reject) => {
       const inputEndpointPath = `${config.data.dataCorrection.dirPath}/_${dataName}.json`;
-      const jsonSanitized = {};
+      const data = {};
 
       const fileStream = fs.createReadStream(inputEndpointPath);
 
       fileStream
         .pipe(JSONStream.parse([{ emitKey: true }]))
         .on("data", ({ key, value }: { key: string; value: any }) => {
-          jsonSanitized[key] = value;
+          data[key] = value;
         })
         .on("error", (error) => reject(error))
-        .on("end", () => resolve(jsonSanitized));
+        .on("end", () => resolve(data));
     });
   }
 }


### PR DESCRIPTION
# Business benefit
Rename a const to be more explicit.

# What I did
- I modified constc named `jsonSanitized` to `data` in `streamData` class function

# Checklist
- [ ] I've updated the tests
- [x] I manually test my feature
- [ ] I've updated the documentations

# How to verify
```bash
$ yarn run_data_correction_junior
```
