### PR TITLE
fix: tsconfig improvement on rebuilds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
       "@types": ["./src/types"]
     }
   },
-  "exclude": ["node_modules", "data", "docs", "__tests", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "data", "docs", "__tests", "**/*.spec.ts"]
 }


### PR DESCRIPTION
# Business benefit
Improve the tsconfig file to avoid error on rebuilds (typescript compiler).

# What I did
- I update the `tsconfig.json` file to add `dist` on `exclude` section.

# Checklist
- [ ] I've updated the tests
- [x] I manually test my feature
- [ ] I've updated the documentations

# How to verify
```bash
$ yarn build
```
