### PR TITLE
chore: add tsconfig for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Exalt IT Katas NodeJS",
   "scripts": {
-    "build": "tsc --project tsconfig.json && tsc-alias -p tsconfig.json",
+    "build": "tsc --project tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "jest",
     "run_bigparsing_confirmed": "node --max_old_space_size=50 dist/src/features/bigparsing_confirmed/index.js",
     "run_data_correction_junior": "node -e 'require(\"./dist/src/features/data_correction_junior/index.js\").dataCorrectionScript()'"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "data",
+    "docs",
+    ".github",
+    "__tests",
+    "**/*.spec.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,5 @@
       "@config": ["./src/config"],
       "@types": ["./src/types"]
     }
-  },
-  "exclude": ["node_modules", "dist", "data", "docs", "__tests", "**/*.spec.ts"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
       "@types": ["./src/types"]
     }
   },
-  "exclude": ["node_modules", "data", "docs", "__tests", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "data", "docs", "__tests", "**/*.spec.ts"]
 }


### PR DESCRIPTION
# Business benefit
Add a specific tsconfig for build (typescript compiler) so that avoid typescript errors on files excluded for build.

# What I did

- I add `tsconfig.build.json`
- I update the `$ yarn build` from `package.json` according to the `tsconfig.build.json`
- I remove `exlude` array from `tsconfig.json`

# Checklist

- [ ] I've updated the tests
- [x] I manually test my feature
- [ ] I've updated the documentations

# How to verify

```bash
$ yarn build
```
